### PR TITLE
Allow lamp names with even characters

### DIFF
--- a/lifxlan/unpack.py
+++ b/lifxlan/unpack.py
@@ -94,12 +94,12 @@ def unpack_lifx_message(packed_message):
         message = GetLabel(target_addr, source_id, seq_num, {}, ack_requested, response_requested)
 
     elif message_type == MSG_IDS[SetLabel]:
-        label = binascii.unhexlify("".join(["%x" % (b & 0x000000ff) for b in struct.unpack("b"*32, payload_str[0:32])]))
+        label = binascii.unhexlify("".join(["%2.2x" % (b & 0x000000ff) for b in struct.unpack("b"*32, payload_str[0:32])]))
         payload = {"label": label}
         message = SetLabel(target_addr, source_id, seq_num, payload, ack_requested, response_requested)
 
     elif message_type == MSG_IDS[StateLabel]:
-        label = binascii.unhexlify("".join(["%x" % (b & 0x000000ff) for b in struct.unpack("b"*32, payload_str[0:32])]))
+        label = binascii.unhexlify("".join(["%2.2x" % (b & 0x000000ff) for b in struct.unpack("b"*32, payload_str[0:32])]))
         payload = {"label": label}
         message = StateLabel(target_addr, source_id, seq_num, payload, ack_requested, response_requested)
 
@@ -151,7 +151,7 @@ def unpack_lifx_message(packed_message):
         color = struct.unpack("H"*4, payload_str[0:8])
         reserved1 = struct.unpack("H", payload_str[8:10])[0]
         power_level = struct.unpack("H", payload_str[10:12])[0]
-        label = binascii.unhexlify("".join(["%x" % (b & 0x000000ff) for b in struct.unpack("b"*32, payload_str[12:44])]))
+        label = binascii.unhexlify("".join(["%2.2x" % (b & 0x000000ff) for b in struct.unpack("b"*32, payload_str[12:44])]))
         reserved2 = struct.unpack("Q", payload_str[44:52])[0]
         payload = {"color": color, "reserved1": reserved1, "power_level": power_level, "label": label, "reserved2": reserved2}
         message = LightState(target_addr, source_id, seq_num, payload, ack_requested, response_requested)


### PR DESCRIPTION
From lovelytwo on https://github.com/mclarkk/lifxlan/issues/11

> In unpack.py modify all %x to %2.2x all ascii characters are two digits
> long, were as the padding is one digit long, so you end up with odd
> number of padding with odd numbers of characters.