### PR TITLE
Fix label packing

### DIFF
--- a/lifxlan/msgtypes.py
+++ b/lifxlan/msgtypes.py
@@ -386,7 +386,7 @@ class LightState(Message):
         color = b"".join(little_endian(bitstring.pack("16", field)) for field in self.color)
         reserved1 = little_endian(bitstring.pack("16", self.reserved1))
         power_level = little_endian(bitstring.pack("16", self.power_level))
-        label = b"".join(little_endian(bitstring.pack("8", ord(c))) for c in self.label)
+        label = b"".join(little_endian(bitstring.pack("8", ord(c))) for c in self.label.decode('utf-8'))
         label_padding = b"".join(little_endian(bitstring.pack("8", 0)) for i in range(32-len(self.label)))
         label += label_padding
         reserved2 = little_endian(bitstring.pack("64", self.reserved1))


### PR DESCRIPTION
Happens with my LIFX A19 bulb.

How to reproduce the issue:

```
~/tmp/lifxlan$ pip3 install lifxlan
Collecting lifxlan
  Using cached lifxlan-1.0.0.tar.gz
Collecting bitstring (from lifxlan)
Building wheels for collected packages: lifxlan
  Running setup.py bdist_wheel for lifxlan ... done
  Stored in directory: /Users/martins/Library/Caches/pip/wheels/97/38/61/dd93e0a5f49752130bcd66a974f87bd0f564ea891e73b1d7c5
Successfully built lifxlan
Installing collected packages: bitstring, lifxlan
Successfully installed bitstring-3.1.5 lifxlan-1.0.0

~/tmp/lifxlan$ python3 examples/hello_world.py

Discovery will go much faster if you provide the number of lights on your LAN:
  python examples/hello_world.py <number of lights on LAN>

Discovering lights...

Found 1 light(s):

Traceback (most recent call last):
  File "examples/hello_world.py", line 30, in <module>
    main()
  File "examples/hello_world.py", line 27, in main
    print(d)
  File "/usr/local/lib/python3.6/site-packages/lifxlan/light.py", line 175, in __str__
    self.refresh()
  File "/usr/local/lib/python3.6/site-packages/lifxlan/device.py", line 90, in refresh
    self.location = self.get_location()
  File "/usr/local/lib/python3.6/site-packages/lifxlan/device.py", line 138, in get_location
    response = self.req_with_resp(GetLocation, StateLocation)
  File "/usr/local/lib/python3.6/site-packages/lifxlan/device.py", line 471, in req_with_resp
    response = unpack_lifx_message(data)
  File "/usr/local/lib/python3.6/site-packages/lifxlan/unpack.py", line 114, in unpack_lifx_message
    message = StateLocation(target_addr, source_id, seq_num, payload, ack_requested, response_requested)
  File "/usr/local/lib/python3.6/site-packages/lifxlan/msgtypes.py", line 251, in __init__
    super(StateLocation, self).__init__(MSG_IDS[StateLocation], target_addr, source_id, seq_num, ack_requested, response_requested)
  File "/usr/local/lib/python3.6/site-packages/lifxlan/message.py", line 43, in __init__
    self.packed_message = self.generate_packed_message()
  File "/usr/local/lib/python3.6/site-packages/lifxlan/message.py", line 46, in generate_packed_message
    self.payload = self.get_payload()
  File "/usr/local/lib/python3.6/site-packages/lifxlan/msgtypes.py", line 258, in get_payload
    label = b"".join(little_endian(bitstring.pack("8", ord(c))) for c in self.label)
  File "/usr/local/lib/python3.6/site-packages/lifxlan/msgtypes.py", line 258, in <genexpr>
    label = b"".join(little_endian(bitstring.pack("8", ord(c))) for c in self.label)
TypeError: ord() expected string of length 1, but int found

~/tmp/lifxlan$ python3 --version
Python 3.6.1
```