### PR TITLE
Fix string/bytes incompatibility

### DIFF
--- a/lifxlan/device.py
+++ b/lifxlan/device.py
@@ -139,7 +139,7 @@ class Device(object):
     def get_location(self):
         try:
             response = self.req_with_resp(GetLocation, StateLocation)
-            self.location = response.label.replace("\x00", "")
+            self.location = response.label.replace(b"\x00", b"")
         except:
             raise
         return self.location
@@ -147,7 +147,7 @@ class Device(object):
     def get_group(self):
         try:
             response = self.req_with_resp(GetGroup, StateGroup)
-            self.group = response.label.replace("\x00", "")
+            self.group = response.label.replace(b"\x00", b"")
         except:
             raise
         return self.group


### PR DESCRIPTION
Fixes another issue with Python 3.6:

```
~/tmp/lifxlan$ venv/bin/python3 examples/hello_world.py

Discovery will go much faster if you provide the number of lights on your LAN:
  python examples/hello_world.py <number of lights on LAN>

Discovering lights...

Found 1 light(s):

Traceback (most recent call last):
  File "examples/hello_world.py", line 30, in <module>
    main()
  File "examples/hello_world.py", line 27, in main
    print(d)
  File "/Users/martins/tmp/lifxlan/lifxlan/light.py", line 178, in __str__
    self.refresh()
  File "/Users/martins/tmp/lifxlan/lifxlan/device.py", line 93, in refresh
    self.location = self.get_location()
  File "/Users/martins/tmp/lifxlan/lifxlan/device.py", line 142, in get_location
    self.location = response.label.replace("\x00", "")
TypeError: a bytes-like object is required, not 'str'

~/tmp/lifxlan$ venv/bin/python3 --version
Python 3.6.1
```