### PR TITLE
Fixed label decode and response.

### DIFF
--- a/lifxlan/device.py
+++ b/lifxlan/device.py
@@ -305,7 +305,7 @@ class Device(object):
         try:
             response = self.req_with_resp(GetGroup, StateGroup)
             self.group = response.group
-            label = response.label.replace("\x00", "")
+            label = response.label.decode('utf-8')
             updated_at = response.updated_at
         except:
             raise


### PR DESCRIPTION
gid, glabel, gupdatedat = d.get_group_tuple()
  File "test.py", line 308, in get_group_tuple
    label = response.label.replace("\x00", "")
TypeError: a bytes-like object is required, not 'str'

Decoding into utf-8 fixes this. 