### PR TITLE
Added LIFX Mini Color product support & fixed issue with multizone light discovery

### DIFF
--- a/lifxlan/multizonelight.py
+++ b/lifxlan/multizonelight.py
@@ -11,7 +11,7 @@ from .msgtypes import MultiZoneGetColorZones, MultiZoneSetColorZones, MultiZoneS
 
 class MultiZoneLight(Light):
     def __init__(self, mac_addr, ip_addr, service=1, port=56700, source_id=0, verbose=False):
-        super(MultiZoneLight, self).__init__(mac_addr, ip_addr)
+        super(MultiZoneLight, self).__init__(mac_addr, ip_addr, service, port, source_id, verbose)
 
     # 0 indexed, inclusive
     def get_color_zones(self, start=0, end=255):

--- a/lifxlan/products.py
+++ b/lifxlan/products.py
@@ -10,14 +10,15 @@ product_map = {1: "Original 1000",
                28: "LIFX BR30",
                29: "LIFX+ A19",
                30: "LIFX+ BR30",
-               31: "LIFX Z"
+               31: "LIFX Z",
+               49: "LIFX Mini Color"
                }
                
 # Identifies which products are lights.
 # Currently all LIFX products that speak the LAN protocol are lights.
 # However, the protocol was written to allow addition of other kinds
 # of devices, so it's important to be able to differentiate.
-light_products = [1, 3, 10, 11, 18, 20, 22, 27, 28, 29, 30, 31]
+light_products = [1, 3, 10, 11, 18, 20, 22, 27, 28, 29, 30, 31, 49]
 
 features_map = {1: {"color": True,
                     "infrared": False,
@@ -54,5 +55,8 @@ features_map = {1: {"color": True,
                      "multizone": False},
                 31: {"color": True,
                      "infrared": False,
-                     "multizone": True}
+                     "multizone": True},
+                49: {"color": True,
+                     "infrared": True,
+                     "multizone": False}
                 }


### PR DESCRIPTION
Just tried to use lifxlan for controlling my lamp setup (1 x LIFX Original, 1 x LIFX Mini Color, 1 x LIFX Z & extension).  Was unable to get either the mini or the Z to enumerate.

The Z would enumerate fine as a Light, but not as a MultiZoneLight,  the Mini would not enumerate at all.

I added support for the Mini Color by updating products.py to include product 49.

I made the LIFX Z enumerate fine as a MultiZoneLight by making a slight change to the constructor (pass all parameters to super() instead of just the first two)

Regards

Nick Harmer
