### PR TITLE
adds missing products from the json directly

### DIFF
--- a/lifxlan/products.json
+++ b/lifxlan/products.json
@@ -1,0 +1,215 @@
+[
+	{
+		"vid": 1,
+		"name": "LIFX",
+		"products": [
+			{
+				"pid": 1,
+				"name": "Original 1000",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 3,
+				"name": "Color 650",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 10,
+				"name": "White 800 (Low Voltage)",
+				"features": {
+					"color": false,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 11,
+				"name": "White 800 (High Voltage)",
+				"features": {
+					"color": false,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 18,
+				"name": "White 900 BR30 (Low Voltage)",
+				"features": {
+					"color": false,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 20,
+				"name": "Color 1000 BR30",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 22,
+				"name": "Color 1000",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 27,
+				"name": "LIFX A19",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 28,
+				"name": "LIFX BR30",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 29,
+				"name": "LIFX+ A19",
+				"features": {
+					"color": true,
+					"infrared": true,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 30,
+				"name": "LIFX+ BR30",
+				"features": {
+					"color": true,
+					"infrared": true,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 31,
+				"name": "LIFX Z",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": true
+				}
+			},
+			{
+				"pid": 32,
+				"name": "LIFX Z 2",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": true
+				}
+			},
+			{
+				"pid": 36,
+				"name": "LIFX Downlight",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 37,
+				"name": "LIFX Downlight",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 43,
+				"name": "LIFX A19",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 44,
+				"name": "LIFX BR30",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 45,
+				"name": "LIFX+ A19",
+				"features": {
+					"color": true,
+					"infrared": true,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 46,
+				"name": "LIFX+ BR30",
+				"features": {
+					"color": true,
+					"infrared": true,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 49,
+				"name": "LIFX Mini",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 50,
+				"name": "LIFX Mini Day and Dusk",
+				"features": {
+					"color": false,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 51,
+				"name": "LIFX Mini White",
+				"features": {
+					"color": false,
+					"infrared": false,
+					"multizone": false
+				}
+			},
+			{
+				"pid": 52,
+				"name": "LIFX GU10",
+				"features": {
+					"color": true,
+					"infrared": false,
+					"multizone": false
+				}
+			}
+		]
+	}
+]

--- a/lifxlan/products.py
+++ b/lifxlan/products.py
@@ -1,58 +1,24 @@
 # coding=utf-8
-product_map = {1: "Original 1000",
-               3: "Color 650",
-               10: "White 800 (Low Voltage)",
-               11: "White 800 (High Voltage)",
-               18: "White 900 BR30 (Low Voltage)",
-               20: "Color 1000 BR30",
-               22: "Color 1000",
-               27: "LIFX A19",
-               28: "LIFX BR30",
-               29: "LIFX+ A19",
-               30: "LIFX+ BR30",
-               31: "LIFX Z"
-               }
-               
+import json
+import os
+
+path = os.path.dirname(__file__)
+products_file = os.path.join(path, "products.json")
+
+with open(products_file) as f:
+    data = json.loads(f.read())
+
+product_map  = {}
+features_map = {}
+
 # Identifies which products are lights.
 # Currently all LIFX products that speak the LAN protocol are lights.
 # However, the protocol was written to allow addition of other kinds
 # of devices, so it's important to be able to differentiate.
-light_products = [1, 3, 10, 11, 18, 20, 22, 27, 28, 29, 30, 31]
+light_products = []
 
-features_map = {1: {"color": True,
-                    "infrared": False,
-                    "multizone": False},
-                3: {"color": True,
-                    "infrared": False,
-                    "multizone": False},
-                10: {"color": False,
-                     "infrared": False,
-                     "multizone": False},
-                11: {"color": False,
-                     "infrared": False,
-                     "multizone": False},
-                18: {"color": False,
-                     "infrared": False,
-                     "multizone": False},
-                20: {"color": True,
-                     "infrared": False,
-                     "multizone": False},
-                22: {"color": True,
-                     "infrared": False,
-                     "multizone": False},
-                27: {"color": True,
-                     "infrared": False,
-                     "multizone": False},
-                28: {"color": True,
-                     "infrared": False,
-                     "multizone": False},
-                29: {"color": True,
-                     "infrared": True,
-                     "multizone": False},
-                30: {"color": True,
-                     "infrared": True,
-                     "multizone": False},
-                31: {"color": True,
-                     "infrared": False,
-                     "multizone": True}
-                }
+for product in data[0]["products"]:
+    pid = product["pid"]
+    product_map[pid]  = product["name"]
+    features_map[pid] = product["features"]
+    light_products.append(pid)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(name='lifxlan',
       author_email='mclarkk@umich.edu',
       license='MIT',
       packages=['lifxlan'],
+      package_data={"": ["products.json"]},
       install_requires=[
         "bitstring",
         ],


### PR DESCRIPTION
we were recently playing with this library with some new lifx mini lights, but they weren't appearing. upon investigation it was because they weren't in the list of known products.

i've made the list of known products now derived from the json file found here - https://github.com/LIFX/products/blob/master/products.json - (i just took a copy of it and placed it in this repo)

this is similar to some other PRs #66 #67 , (though 67 _also_ fixes some bug)

thanks for this library by the way, it's been a fun way to get to know the lights!