### PR TITLE
Switch from netifaces to ifaddr.

### DIFF
--- a/lifxlan/device.py
+++ b/lifxlan/device.py
@@ -21,8 +21,9 @@
 from datetime import datetime
 from socket import AF_INET, SOCK_DGRAM, SOL_SOCKET, SO_BROADCAST, SO_REUSEADDR, socket, timeout, gethostbyname_ex, gethostname
 from time import sleep, time
+import ifaddr
 import platform
-import netifaces as ni
+import struct
 
 from .errors import WorkflowException
 from .msgtypes import Acknowledgement, GetGroup, GetHostFirmware, GetInfo, GetLabel, GetLocation, GetPower, GetVersion, \
@@ -39,13 +40,32 @@ VERBOSE = False
 
 def get_broadcast_addrs():
     broadcast_addrs = []
-    for iface in ni.interfaces():
-        try:
-            ifaddr = ni.ifaddresses(iface)[ni.AF_INET][0]
-            if ifaddr['addr'] != '127.0.0.1':
-                broadcast_addrs.append(ifaddr['broadcast'])
-        except: # for interfaces that don't support ni.AF_INET
-            pass
+    for iface in ifaddr.get_adapters():
+        for addr in iface.ips:
+            if not addr.is_IPv4:
+                continue
+
+            ip = addr.ip
+            prefix = addr.network_prefix
+
+            if ip == '127.0.0.1':
+                continue
+
+            numeric = struct.unpack(
+                '>I',
+                struct.pack('BBBB', *[int(x, 10) for x in ip.split('.')])
+            )[0]
+            mask = ~int('1' * prefix + '0' * (32 - prefix), 2) & 0xffffffff
+
+            broadcast = '.'.join(
+                str(x) for x in struct.unpack(
+                    'BBBB',
+                    struct.pack('>I', numeric | mask)
+                )
+            )
+
+            broadcast_addrs.append(broadcast)
+
     return broadcast_addrs
 
 UDP_BROADCAST_IP_ADDRS = get_broadcast_addrs()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 import re
 
 with open("lifxlan/__init__.py") as meta_file:
-    metadata = dict(re.findall("__([a-z]+)__\s*=\s*'([^']+)'", meta_file.read()))
+    metadata = dict(re.findall(r"__([a-z]+)__\s*=\s*'([^']+)'", meta_file.read()))
 
 setup(name='lifxlan',
       version=metadata['version'],
@@ -15,11 +15,11 @@ setup(name='lifxlan',
       packages=['lifxlan'],
       install_requires=[
         "bitstring",
-        "netifaces"
-        ],
+        "ifaddr"
+      ],
       zip_safe=False,
-          # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    classifiers=[
+      # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+      classifiers=[
         # Pick your license as you wish (should match "license" above)
         'License :: OSI Approved :: MIT License',
 
@@ -33,4 +33,4 @@ setup(name='lifxlan',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6'
-    ])
+      ])


### PR DESCRIPTION
ifaddr is pure Python and does not require a toolchain to be
installed.

The struct packing/unpacking and math to find the broadcast
address could easily be done with the ipaddress module in the
standard library, but that's only for Python 3.x.