### PR TITLE
allow skipping discovery when getting devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ LifxLAN objects have the following methods:
 # group is a string label for a group, such as "Living Room"
 # location is the string label for a location, such as "My Home"
 
-get_lights()                                                                                 # returns list of Light objects
-get_color_lights()                                                                           # returns list of Light objects that support color functionality
+get_lights([perform_discovery])                                                              # returns list of Light objects
+get_color_lights([perform_discovery])                                                        # returns list of Light objects that support color functionality
 get_infrared_lights()                                                                        # returns list of Light objects that support infrared functionality
 get_multizone_lights()                                                                       # returns list of MultiZoneLight objects that support multizone functionality
 get_tilechain_lights()                                                                       # returns a list of TileChain objects that support chain functionality
@@ -131,7 +131,7 @@ supports_infrared()                 # returns True if product features include i
 You can get Light objects automatically though LAN-based discovery (takes a few seconds), or by creating Light objects using a known MAC address and IP address:
 
 ```
-lights = lan.get_lights()                              # Option 1: Discovery
+lights = lan.discover_devices()                        # Option 1: Discovery
 light = Light("12:34:56:78:9a:bc", "192.168.1.42")     # Option 2: Direct
 ```
 

--- a/lifxlan/lifxlan.py
+++ b/lifxlan/lifxlan.py
@@ -34,12 +34,18 @@ class LifxLAN:
     #                                                                          #
     ############################################################################
 
-    def get_devices(self):
-        self.discover_devices()
+    # if you override perform_discovery please ensure you run discover_devices at least once
+    # additionally please ensure you run discovery_lights regularily in the event lights change ip address or new lights become available
+    def get_devices(self, perform_discovery=True):
+        if perform_discovery:
+            self.discover_devices()
         return self.devices
 
-    def get_lights(self):
-        self.discover_devices()
+    # if you override perform_discovery please ensure you run discover_devices at least once
+    # additionally please ensure you run discovery_lights regularily in the event lights change ip address or new lights become available
+    def get_lights(self, perform_discovery=True):
+        if perform_discovery:
+            self.discover_devices()
         return self.lights
 
     # more of an internal helper function


### PR DESCRIPTION
When performing many operations which call `get_lights` or `get_devices` there is a significant delay in order to allow the discovery process to complete.

This PR has the following use case in mind: placing lifxlan behind a RESTful API or a queue. This means whenever an operation is requested the target device is looked up making use of functions such as `get_device_by_name` for each request. `get_device_by_name` for example calls `get_devices` which in turn performs discovery. For tasks which benefit from quick execution such as manipulating lights to the beat of music, performing discovery each time is not desirable.

Thus new optional parameters have been introduced to allow you to skip the discovery process for `get_lights` and `get_devices`. The changes are written in such a way that the default ensures the discovery process is run each time unless otherwise stated - this means that other parts of the lifxlan code base do not need to be altered, and users of lifxlan should not need to change their own projects.

An alternative solution would be to keep a list of devices handy outside of lifxlan, however why re-invent the wheel when the current implementation is well thought out.

The only downside to the proposed solution would be that discovery needs to be performed at least once, and regularly to ensure that the known devices list is populated in the first place and kept up to date - comments have been added to emphasize this.