### PR TITLE
allow skipping discovery when getting devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ LifxLAN objects have the following methods:
 # group is a string label for a group, such as "Living Room"
 # location is the string label for a location, such as "My Home"
 
-get_lights()                                                                                 # returns list of Light objects
-get_color_lights()                                                                           # returns list of Light objects that support color functionality
+get_lights([refresh])                                                                        # returns list of Light objects
+get_color_lights([refresh])                                                                  # returns list of Light objects that support color functionality
 get_infrared_lights()                                                                        # returns list of Light objects that support infrared functionality
 get_multizone_lights()                                                                       # returns list of MultiZoneLight objects that support multizone functionality
 get_tilechain_lights()                                                                       # returns a list of TileChain objects that support chain functionality
@@ -131,7 +131,7 @@ supports_infrared()                 # returns True if product features include i
 You can get Light objects automatically though LAN-based discovery (takes a few seconds), or by creating Light objects using a known MAC address and IP address:
 
 ```
-lights = lan.get_lights()                              # Option 1: Discovery
+lights = lan.discover_devices()                        # Option 1: Discovery
 light = Light("12:34:56:78:9a:bc", "192.168.1.42")     # Option 2: Direct
 ```
 

--- a/lifxlan/lifxlan.py
+++ b/lifxlan/lifxlan.py
@@ -34,12 +34,14 @@ class LifxLAN:
     #                                                                          #
     ############################################################################
 
-    def get_devices(self):
-        self.discover_devices()
+    def get_devices(self, refresh=False):
+        if self.devices == None or refresh == True:
+            self.discover_devices()
         return self.devices
 
-    def get_lights(self):
-        self.discover_devices()
+    def get_lights(self, refresh=False):
+        if self.lights == None or refresh == True:
+            self.discover_devices()
         return self.lights
 
     # more of an internal helper function
@@ -103,9 +105,8 @@ class LifxLAN:
         for d in all_devices:
             if d.get_label() == name:
                 device = d
-        if device == None:               # didn't find it?
-            self.discover_devices()      # update list in case it is out of date
-            all_devices = self.get_devices()
+        if device == None:                        # didn't find it?
+            all_devices = self.get_devices(True)  # update list in case it is out of date
             for d in all_devices:            # and try again
                 if d.get_label() == name:
                     device = d
@@ -118,9 +119,8 @@ class LifxLAN:
         for d in all_devices:
             if d.get_label() in names:
                 devices.append(d)
-        if len(devices) != len(names):  # didn't find everything?
-            self.discover_devices()     # update list in case it is out of date
-            all_devices = self.get_devices()
+        if len(devices) != len(names):            # didn't find everything?
+            all_devices = self.get_devices(True)  # update list in case it is out of date
             for d in all_devices:       # and try again
                 if d.get_label() in names:
                     devices.append(d)
@@ -147,7 +147,7 @@ class LifxLAN:
         responses = self.broadcast_with_resp(LightGetPower, LightStatePower)
         power_states = {}
         if self.lights == None:
-            self.lights = self.get_lights()
+            self.lights = self.get_lights(True)
         for light in self.lights:
             for response in responses:
                 if light.mac_addr == response.target_addr:
@@ -175,7 +175,7 @@ class LifxLAN:
         responses = self.broadcast_with_resp(LightGet, LightState)
         colors = {}
         if self.lights == None:
-            self.lights = self.get_lights()
+            self.lights = self.get_lights(True)
         for light in self.lights:
             for response in responses:
                 if light.mac_addr == response.target_addr:


### PR DESCRIPTION
Take 2.

When performing many operations which call `get_lights` or `get_devices` there is a significant delay in order to allow the discovery process to complete.

This PR has the following use case in mind: placing lifxlan behind a RESTful API or a queue. This means whenever a client contacts lifxlan via the RESTful API or queue the target device or group is looked up each time before an operation is performed using functions like: `get_device_by_name` or `get_group_by_name`. Those functions currently call`get_devices` which in turn performs discovery. For tasks which benefit from quick execution such as manipulating lights to the beat of music, performing discovery each time is not desirable.

Thus new optional parameters have been introduced to allow you to skip the discovery process for `get_lights` and `get_devices`. Hopefully these changes should have no or minimal impact on other functions, or users who use lifxlan.