### PR TITLE
Fix for #146; obtain a random number

### DIFF
--- a/lifxlan/lifxlan.py
+++ b/lifxlan/lifxlan.py
@@ -5,7 +5,7 @@
 from random import randint
 from socket import AF_INET, SOCK_DGRAM, SOL_SOCKET, SO_BROADCAST, SO_REUSEADDR, socket, timeout
 from time import sleep, time
-import os
+import random
 
 from .device import DEFAULT_ATTEMPTS, DEFAULT_TIMEOUT, Device, UDP_BROADCAST_IP_ADDRS, UDP_BROADCAST_PORT
 from .errors import InvalidParameterException, WorkflowException
@@ -21,7 +21,7 @@ from .group import Group
 
 class LifxLAN:
     def __init__(self, num_lights=None, verbose=False):
-        self.source_id = os.getpid()
+        self.source_id = random.randrange(2, 1 << 32)
         self.num_devices = num_lights
         self.num_lights = num_lights
         self.devices = None

--- a/lifxlan/light.py
+++ b/lifxlan/light.py
@@ -2,7 +2,7 @@
 # light.py
 # Author: Meghan Clark
 
-import os
+import random
 from .device import Device
 from .errors import InvalidParameterException, WorkflowException
 from .msgtypes import LightGet, LightGetInfrared, LightGetPower,\
@@ -23,7 +23,7 @@ WARM_WHITE = [58275, 0, 65535, 3200]
 GOLD = [58275, 0, 65535, 2500]
 
 class Light(Device):
-    def __init__(self, mac_addr, ip_addr, service=1, port=56700, source_id=os.getpid(), verbose=False):
+    def __init__(self, mac_addr, ip_addr, service=1, port=56700, source_id=random.randrange(2, 1 << 32), verbose=False):
         mac_addr = mac_addr.lower()
         super(Light, self).__init__(mac_addr, ip_addr, service, port, source_id, verbose)
         self.color = None

--- a/lifxlan/multizonelight.py
+++ b/lifxlan/multizonelight.py
@@ -2,7 +2,7 @@
 # multizonelight.py
 
 import math
-import os
+import random
 
 from .device import WorkflowException
 from .light import Light
@@ -10,7 +10,7 @@ from .msgtypes import MultiZoneGetColorZones, MultiZoneSetColorZones, MultiZoneS
 
 
 class MultiZoneLight(Light):
-    def __init__(self, mac_addr, ip_addr, service=1, port=56700, source_id=os.getpid(), verbose=False):
+    def __init__(self, mac_addr, ip_addr, service=1, port=56700, source_id=random.randrange(2, 1 << 32), verbose=False):
         super(MultiZoneLight, self).__init__(mac_addr, ip_addr, service, port, source_id, verbose)
 
     # 0 indexed, NOT inclusive, works like python list indices

--- a/lifxlan/tilechain.py
+++ b/lifxlan/tilechain.py
@@ -1,4 +1,4 @@
-import os
+import random
 
 from .errors import WorkflowException, InvalidParameterException
 from .light import Light
@@ -6,7 +6,7 @@ from .msgtypes import GetTileState64, StateTileState64, SetTileState64, GetDevic
 from threading import Thread
 
 class TileChain(Light):
-    def __init__(self, mac_addr, ip_addr, service=1, port=56700, source_id=os.getpid(), verbose=False):
+    def __init__(self, mac_addr, ip_addr, service=1, port=56700, source_id=random.randrange(2, 1 << 32), verbose=False):
         super(TileChain, self).__init__(mac_addr, ip_addr, service, port, source_id, verbose)
         self.tile_info = None
         self.tile_count = None


### PR DESCRIPTION
This essentially reverts https://github.com/mclarkk/lifxlan/commit/c5ed8f4ae6248fbddf0c3be0f201857da399c329 so it might not be the solution that would be accepted by maintainer.

An alternative would be to allow setting of the source ID during construction of the LifxLAN object.