### PR TITLE
Add LIFX Beam to `lights` list in products.py, casting it as a `MultiZoneLight`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# This is samclane's dev fork of lifxlan
-
 # lifxlan
 
 **lifxlan** is a Python 2 and Python 3 module for locally controlling LIFX devices (such as lightbulbs) over a LAN. It implements the [LIFX LAN Protocol](https://lan.developer.lifx.com/) specification. Supports white, color, multizone (LIFX Z, LIFX Beam), infrared (LIFX+), and chain (LIFX Tile) capabilities. Also supports group-based control of arbitrary sets of lights. Supports Unicode characters in names, groups, and locations.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This is samclane's dev fork of lifxlan
+
 # lifxlan
 
 **lifxlan** is a Python 2 and Python 3 module for locally controlling LIFX devices (such as lightbulbs) over a LAN. It implements the [LIFX LAN Protocol](https://lan.developer.lifx.com/) specification. Supports white, color, multizone (LIFX Z, LIFX Beam), infrared (LIFX+), and chain (LIFX Tile) capabilities. Also supports group-based control of arbitrary sets of lights. Supports Unicode characters in names, groups, and locations.

--- a/lifxlan/products.py
+++ b/lifxlan/products.py
@@ -36,7 +36,7 @@ product_map = {1: "Original 1000",
 # Currently all LIFX products that speak the LAN protocol are lights.
 # However, the protocol was written to allow addition of other kinds
 # of devices, so it's important to be able to differentiate.
-light_products = [1, 3, 10, 11, 18, 20, 22, 27, 28, 29, 30, 31, 32, 36, 37, 43, 44, 45, 46, 49, 50, 51, 52, 55, 57, 59, 60, 61, 62, 68]
+light_products = [1, 3, 10, 11, 18, 20, 22, 27, 28, 29, 30, 31, 32, 36, 37, 38, 43, 44, 45, 46, 49, 50, 51, 52, 55, 57, 59, 60, 61, 62, 68]
 
 features_map = {1: {"color": True,
                     "temperature": True,


### PR DESCRIPTION
Currently, whenever a LIFX Beam is a part of a Group, it's cast as a generic `Device`, limiting its function. In `products.py`, its index is excluded from `lights`, so it's never cast correctly.

I tried testing this by adding the index to the lights list at Runtime in a REPL, which caused it to be discovered as a MultiZoneLight next time I ran `LifxLAN().discover`