### PR TITLE
There's a sleep after every send instead of just between repeated

### DIFF
--- a/lifxlan/device.py
+++ b/lifxlan/device.py
@@ -500,7 +500,8 @@ class Device(object):
             if self.verbose:
                 print("SEND: " + str(msg))
             sent_msg_count += 1
-            sleep(sleep_interval) # Max num of messages device can handle is 20 per second.
+            if sent_msg_count < num_repeats:
+                sleep(sleep_interval) # Max num of messages device can handle is 20 per second.
         self.close_socket(socket_id)
 
     # Usually used for Set messages

--- a/lifxlan/lifxlan.py
+++ b/lifxlan/lifxlan.py
@@ -241,7 +241,8 @@ class LifxLAN:
             if self.verbose:
                 print("SEND: " + str(msg))
             sent_msg_count += 1
-            sleep(sleep_interval) # Max num of messages device can handle is 20 per second.
+            if sent_msg_count < num_repeats:
+                sleep(sleep_interval) # Max num of messages device can handle is 20 per second.
         self.close_socket()
 
     def broadcast_with_resp(self, msg_type, response_type, payload={}, timeout_secs=DEFAULT_TIMEOUT, max_attempts=DEFAULT_ATTEMPTS):


### PR DESCRIPTION
sends, including those of related commands in a batch operation.  On a raspberry pi, the sleeps seem to be a lot more expensive than just 0.05 seconds (context switching is very expensive on those tiny Arms), so the whole command ends up taking about 10 seconds to execute.  Just assume the LIFX can put up with getting a couple of requests quickly -- we're not sending too many of them.

With the sleep at the end of the loop:

10514,20> time ./get_lights 2
Discovering lights...
Found 2 lights:
Bedroom (d0:73:d5:26:d2:00) P: 0 (HSBK): (0, 0, 44563, 4000) Porch (d0:73:d5:30:f2:93) P: 0 (HSBK): (0, 0, 3276, 4000)

real    0m9.268s
user    0m2.066s
sys     0m0.321s

With the last sleep removed:

0-0-18:46:23, Tue Aug 28 tconnors@pi:~/bin (bash)
10514,21> time ./get_lights 2
Discovering lights...
Found 2 lights:
Bedroom (d0:73:d5:26:d2:00) P: 0 (HSBK): (0, 0, 44563, 4000) Porch (d0:73:d5:30:f2:93) P: 0 (HSBK): (0, 0, 3276, 4000)

real    0m5.613s
user    0m1.966s
sys     0m0.309s